### PR TITLE
Fix for error when missing MySQLdb

### DIFF
--- a/appengine/standard_python37/django/mysite/settings.py
+++ b/appengine/standard_python37/django/mysite/settings.py
@@ -79,6 +79,16 @@ WSGI_APPLICATION = 'mysite.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
+# Check to see if MySQLdb is available; if not, have pymysql masquerade as
+# MySQLdb. This is a convenience feature for developers who cannot install
+# MySQLdb locally; when running in production on Google App Engine Standard
+# Environment, MySQLdb will be used.
+try:
+    import MySQLdb  # noqa: F401
+except ImportError:
+    import pymysql
+    pymysql.install_as_MySQLdb()
+
 # [START db_setup]
 if os.getenv('GAE_APPLICATION', None):
     # Running on production App Engine, so connect to Google Cloud SQL using


### PR DESCRIPTION
While looking into the cause of the exception, I noticed the pymysql init was missing, and it was done for the django2 tutorial.

Note that this was noticed even when running the app in ["production" on GAE](https://console.cloud.google.com/errors/CIv9orry98OZRw?time=PT1H&project=expanded-talon-217815) (link my own error if accessible by Google employees).
